### PR TITLE
remove subdomain wildcard from plausible csp reference

### DIFF
--- a/app/pkg/web/engine.go
+++ b/app/pkg/web/engine.go
@@ -28,14 +28,14 @@ import (
 var (
 	cspBase    = "base-uri 'self'"
 	cspDefault = "default-src 'self'"
-	cspStyle   = "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paddle.com https://*.plausible.io %[2]s"
-	cspScript  = "script-src 'self' 'nonce-%[1]s' https://www.google-analytics.com https://*.paddle.com https://*.plausible.io %[2]s"
+	cspStyle   = "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paddle.com https://plausible.io %[2]s"
+	cspScript  = "script-src 'self' 'nonce-%[1]s' https://www.google-analytics.com https://*.paddle.com https://plausible.io %[2]s"
 	cspFont    = "font-src 'self' https://fonts.gstatic.com data: %[2]s"
 	cspImage   = "img-src 'self' https: data: %[2]s"
 	cspObject  = "object-src 'none'"
 	cspFrame   = "frame-src 'self' https://*.paddle.com"
 	cspMedia   = "media-src 'none'"
-	cspConnect = "connect-src 'self' https://www.google-analytics.com https://*.plausible.io %[2]s"
+	cspConnect = "connect-src 'self' https://www.google-analytics.com https://plausible.io %[2]s"
 
 	//CspPolicyTemplate is the template used to generate the policy
 	CspPolicyTemplate = fmt.Sprintf("%s; %s; %s; %s; %s; %s; %s; %s; %s; %s", cspBase, cspDefault, cspStyle, cspScript, cspImage, cspFont, cspObject, cspMedia, cspConnect, cspFrame)


### PR DESCRIPTION
Remove subdomain wildcard from plausible csp reference to just use domain root.